### PR TITLE
Avoid overflow by manually checking signage of offset in File::seek

### DIFF
--- a/library/std/src/sys/switch/fs.rs
+++ b/library/std/src/sys/switch/fs.rs
@@ -506,7 +506,11 @@ impl File {
                         "Attempted to seek to an invalid or negative offset"
                     ))
                 }
-                self.pos.store(self.attr.size() + (offset as u64), Ordering::SeqCst);
+                if offset < 0 {
+                    self.pos.store(self.attr.size() - (-offset as u64), Ordering::SeqCst);
+                } else {
+                    self.pos.store(self.attr.size() + (offset as u64), Ordering::SeqCst);
+                }
             },
         };
 

--- a/library/std/src/sys/switch/fs.rs
+++ b/library/std/src/sys/switch/fs.rs
@@ -506,7 +506,7 @@ impl File {
                         "Attempted to seek to an invalid or negative offset"
                     ))
                 }
-                self.pos.store(self.attr.size() + (-offset as u64), Ordering::SeqCst);
+                self.pos.store(self.attr.size() + (offset as u64), Ordering::SeqCst);
             },
         };
 


### PR DESCRIPTION
sorry about the multiple pull requests, didn't know about rust overflow behavior