### PR TITLE
Add clippy to build artifacts

### DIFF
--- a/.github/workflows/skyline_release.yml
+++ b/.github/workflows/skyline_release.yml
@@ -51,6 +51,10 @@ jobs:
         echo "target_triple=x86_64-apple-darwin" >> $GITHUB_ENV
     - name: Package Release
       run: |
+        # Include tools (clippy, rustdoc, etc.) in build artifact
+        rm -rf build/${{ env.target_triple }}/stage2-tools/${{ env.target_triple }}/release/*/ # We only want executables
+        cp -r build/${{ env.target_triple }}/stage2-tools/${{ env.target_triple }}/release/* build/${{ env.target_triple }}/stage2
+        # Build the archive
         rust-zip build/${{ env.target_triple }}/stage2 build-${{ env.target_triple }}.zip
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
This merges the build output of `stage2-tools` with the regular `stage2` output, making tool executables and libraries (for `rustdoc`, `clippy`, etc.) available in the toolchain.

I have tested the commands individually but I don't know whether they work in CI.

As a side note, the base of this PR is `working-backup`, as I couldn't get `master` to compile.